### PR TITLE
Handle google.protobuf.Timestamp type in protoc-gen-openapi URL query parameters

### DIFF
--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/message.proto
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/message.proto
@@ -23,6 +23,7 @@ import "google/api/httpbody.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/google/gnostic/apps/protoc-gen-openapi/examples/tests/protobuftypes/message/v1;message";
 
@@ -111,4 +112,5 @@ message Message {
   google.protobuf.UInt64Value uint64_value_type = 21;
   google.protobuf.FloatValue float_value_type = 22;
   google.protobuf.DoubleValue double_value_type = 23;
+  google.protobuf.Timestamp timestamp_type = 24;
 }

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
@@ -139,6 +139,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestamp_type
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             responses:
                 "200":
                     description: OK
@@ -293,6 +298,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestamp_type
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             requestBody:
                 content:
                     application/json:
@@ -431,6 +441,9 @@ components:
                 double_value_type:
                     type: number
                     format: double
+                timestamp_type:
+                    type: string
+                    format: date-time
         Message_EmbMessage:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_default_response.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_default_response.yaml
@@ -139,6 +139,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             responses:
                 "200":
                     description: OK
@@ -293,6 +298,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             requestBody:
                 content:
                     application/json:
@@ -431,6 +441,9 @@ components:
                 doubleValueType:
                     type: number
                     format: double
+                timestampType:
+                    type: string
+                    format: date-time
         Message_EmbMessage:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_fq_schema_naming.yaml
@@ -139,6 +139,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             responses:
                 "200":
                     description: OK
@@ -293,6 +298,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             requestBody:
                 content:
                     application/json:
@@ -447,6 +457,9 @@ components:
                 doubleValueType:
                     type: number
                     format: double
+                timestampType:
+                    type: string
+                    format: date-time
         tests.protobuftypes.message.v1.Message_EmbMessage:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -139,6 +139,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             responses:
                 "200":
                     description: OK
@@ -293,6 +298,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             requestBody:
                 content:
                     application/json:
@@ -431,6 +441,9 @@ components:
                 doubleValueType:
                     type: number
                     format: double
+                timestampType:
+                    type: string
+                    format: date-time
         Message_EmbMessage:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_string_enum.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_string_enum.yaml
@@ -139,6 +139,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             responses:
                 "200":
                     description: OK
@@ -293,6 +298,11 @@ paths:
                   schema:
                     type: number
                     format: double
+                - name: timestampType
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
             requestBody:
                 content:
                     application/json:
@@ -431,6 +441,9 @@ components:
                 doubleValueType:
                     type: number
                     format: double
+                timestampType:
+                    type: string
+                    format: date-time
         Message_EmbMessage:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -272,7 +272,10 @@ func (g *OpenAPIv3Generator) findAndFormatFieldName(name string, inMessage *prot
 // or a repeated primitive type or a non-repeated message type.
 // In the case of a repeated type, the parameter can be repeated in the URL as ...?param=A&param=B.
 // In the case of a message type, each field of the message is mapped to a separate parameter,
-// such as ...?foo.a=A&foo.b=B&foo.c=C. Except for google.protobuf.timestamp type it will be serialized as a string
+// such as ...?foo.a=A&foo.b=B&foo.c=C.
+// There are exceptions:
+// - for wrapper types it will use the same representation as the wrapped primitive type in JSON
+// - for google.protobuf.timestamp type it will be serialized as a string
 //
 // maps, Struct and Empty can NOT be used
 // messages can have any number of sub messages - including circular (e.g. sub.subsub.sub.subsub.id)

--- a/cmd/protoc-gen-openapi/generator/generator.go
+++ b/cmd/protoc-gen-openapi/generator/generator.go
@@ -272,7 +272,7 @@ func (g *OpenAPIv3Generator) findAndFormatFieldName(name string, inMessage *prot
 // or a repeated primitive type or a non-repeated message type.
 // In the case of a repeated type, the parameter can be repeated in the URL as ...?param=A&param=B.
 // In the case of a message type, each field of the message is mapped to a separate parameter,
-// such as ...?foo.a=A&foo.b=B&foo.c=C.
+// such as ...?foo.a=A&foo.b=B&foo.c=C. Except for google.protobuf.timestamp type it will be serialized as a string
 //
 // maps, Struct and Empty can NOT be used
 // messages can have any number of sub messages - including circular (e.g. sub.subsub.sub.subsub.id)
@@ -319,6 +319,22 @@ func (g *OpenAPIv3Generator) _buildQueryParamsV3(field *protogen.Field, depths m
 			".google.protobuf.DoubleValue":
 			valueField := getValueField(field.Message.Desc)
 			fieldSchema := g.reflect.schemaOrReferenceForField(valueField)
+			parameters = append(parameters,
+				&v3.ParameterOrReference{
+					Oneof: &v3.ParameterOrReference_Parameter{
+						Parameter: &v3.Parameter{
+							Name:        queryFieldName,
+							In:          "query",
+							Description: fieldDescription,
+							Required:    false,
+							Schema:      fieldSchema,
+						},
+					},
+				})
+			return parameters
+
+		case ".google.protobuf.Timestamp":
+			fieldSchema := g.reflect.schemaOrReferenceForMessage(field.Message.Desc)
 			parameters = append(parameters,
 				&v3.ParameterOrReference{
 					Oneof: &v3.ParameterOrReference_Parameter{


### PR DESCRIPTION
## Issue Description
A field with `google.protobuf.Timestamp` type when used as URL query parameters will be mapped into  a custom object. Meanwhile if it is used as a request body, it will be mapped into string (as defined in https://developers.google.com/protocol-buffers/docs/proto3#json)

For instance:
```protobuf
service Messaging {
  rpc GetMessage(Message) returns (Message) {
    option (google.api.http) = {
      get : "/v1/messages/{message_id}"
    };
  }
}

message Message {
  string message_id = 1;
  google.protobuf.Timestamp timestamp_type = 2;
}
```
is converted into:
```yaml
paths:
    /v1/messages/{messageId}:
        get:
            tags:
                - Messaging
            operationId: Messaging_GetMessage
            parameters:
                - name: messageId
                  in: path
                  required: true
                  schema:
                    type: string
                - name: timestampType.seconds
                  in: query
                  description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
                  schema:
                    type: string
                - name: timestampType.nanos
                  in: query
                  description: Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive.
                  schema:
                    type: integer
                    format: int32
```
![image](https://user-images.githubusercontent.com/8855599/190633501-9fa845f7-8334-4fba-baab-ae081b69007b.png)

## Changes Proposal
In this Pull Request I propose to map `google.protobuf.Timestamp` into string when used as a URL query parameters.

With this changes, the same protobuf definition above will be converted into:
```yaml
paths:
    /v1/messages/{message_id}:
        get:
            tags:
                - Messaging
            operationId: Messaging_GetMessage
            parameters:
                - name: message_id
                  in: path
                  required: true
                  schema:
                    type: string
                - name: timestamp_type
                  in: query
                  schema:
                    type: string
                    format: date-time
```
![image](https://user-images.githubusercontent.com/8855599/190633651-9f23c159-e08e-48be-a023-f9fa7bba8f89.png)

